### PR TITLE
Add agent auth to list host api query

### DIFF
--- a/Dockerfile.ignition-manifests-and-kubeconfig-generate
+++ b/Dockerfile.ignition-manifests-and-kubeconfig-generate
@@ -2,7 +2,7 @@
 FROM quay.io/ocpmetal/openshift-installer
 # [TODO] - add someway to get oc client in order to use it to extract openshift-baremetal-install executable
 # FROM quay.io/yshnaidm/oc-image:latest
-FROM quay.io/ocpmetal/bm-inventory:latest AS inventory
+FROM quay.io/ocpmetal/assisted-service:latest AS inventory
 
 
 FROM centos:8
@@ -12,7 +12,7 @@ RUN dnf install -y libvirt-libs python3 findutils wget && \
 
 
 COPY requirements.txt /tmp/requirements.txt
-COPY --from=inventory /clients/bm-inventory-client-*.tar.gz /build/pip/
+COPY --from=inventory /clients/assisted-service-client-*.tar.gz /build/pip/
 RUN pip3 install -r /tmp/requirements.txt
 RUN pip3 install ipython
 RUN find /build/pip/ -name 'setup.py' -exec dirname {} \; | xargs pip3 install

--- a/render_files.py
+++ b/render_files.py
@@ -41,10 +41,10 @@ def upload_to_aws(s3_client, local_file, bucket, s3_file):
         return False
 
 
-def update_bmh_files(ignition_file, cluster_id, inventory_endpoint):
+def update_bmh_files(ignition_file, cluster_id, inventory_endpoint, token):
     try:
         if inventory_endpoint:
-            hosts_list = utils.get_inventory_hosts(inventory_endpoint, cluster_id)
+            hosts_list = utils.get_inventory_hosts(inventory_endpoint, cluster_id, token)
         else:
             logging.info("Using test data to get hosts list")
             hosts_list = test_utils.get_test_list_hosts(cluster_id)
@@ -126,11 +126,14 @@ def prepare_install_config(config_dir, install_config):
             yaml_file.write(install_config)
 
 
-def set_pull_secret(config_dir):
+def pull_secret(config_dir):
     with open(os.path.join(config_dir, INSTALL_CONFIG), 'r') as yaml_file:
-        pull_secret = yaml.safe_load(yaml_file)['pullSecret']
+        return yaml.safe_load(yaml_file)['pullSecret']
+
+
+def set_pull_secret(config_dir):
     with open('/root/.docker/config.json', 'w+') as config_file:
-        config_file.write(pull_secret)
+        config_file.write(pull_secret(config_dir))
 
 
 def prepare_generation_data(work_dir, config_dir, install_config, openshift_release_image):
@@ -143,6 +146,11 @@ def create_config_dir(work_dir):
     config_dir = os.path.join(work_dir, "installer_dir")
     subprocess.check_output(["mkdir", "-p", config_dir])
     return config_dir
+
+
+def openshift_token(config_dir):
+    secret = json.loads(pull_secret(config_dir))
+    return secret["auths"]["cloud.openshift.com"]["auth"]
 
 
 def create_services_config(work_dir, config_dir, openshift_release_image):
@@ -184,7 +192,7 @@ def main():
     create_services_config(work_dir, config_dir, openshift_release_image)
 
     # update BMH configuration in boostrap ignition
-    update_bmh_files("%s/bootstrap.ign" % config_dir, cluster_id, inventory_endpoint)
+    update_bmh_files("%s/bootstrap.ign" % config_dir, cluster_id, inventory_endpoint, openshift_token(config_dir))
 
     if s3_endpoint_url:
         upload_to_s3(s3_endpoint_url, bucket, aws_access_key_id, aws_secret_access_key, config_dir, cluster_id)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import os
 import json
-from bm_inventory_client import ApiClient, Configuration, api, models
+from assisted_service_client import ApiClient, Configuration, api, models
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -50,9 +50,10 @@ class InventoryHost:
         return " "
 
 
-def get_inventory_hosts(inventory_endpoint, cluster_id):
+def get_inventory_hosts(inventory_endpoint, cluster_id, token):
     configs = Configuration()
     configs.host = inventory_endpoint
+    configs.api_key["X-Secret-Key"] = token
     apiClient = ApiClient(configuration=configs)
     client = api.InstallerApi(api_client=apiClient)
     hosts_list = client.list_hosts(cluster_id=cluster_id)


### PR DESCRIPTION
Previously the call to list the hosts would fail with a 401 if auth was enabled in the assisted-service

built on https://github.com/oshercc/ignition-manifests-and-kubeconfig-generate/pull/18

I think this also needs a patch to assisted-installer to allow agent auth for host list GET requests, but I didn't get a chance to test that.

Something like this I imagine?
```patch
diff --git a/swagger.yaml b/swagger.yaml
index e0ab38e..0705c28 100644
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -732,6 +732,9 @@ paths:
     get:
       tags:
         - installer
+      security:
+        - agentAuth: []
+        - userAuth: []
       summary: Retrieves the list of OpenShift bare metal hosts.
       operationId: ListHosts
       parameters:
```

cc @rollandf